### PR TITLE
style: 푸터 인증 로고 모바일 2x2 좌측 정렬 반응형 적용

### DIFF
--- a/src/components/layout/Footer/CompanyCertifications.tsx
+++ b/src/components/layout/Footer/CompanyCertifications.tsx
@@ -9,7 +9,7 @@ const CompanyCertifications = async () => {
   const t = await getTranslations('footer');
 
   return (
-    <div className="flex flex-row gap-7 lg:gap-10">
+    <div className="grid grid-cols-[auto_auto] justify-start place-items-start gap-7 sm:flex sm:flex-row sm:place-items-stretch lg:gap-10">
       <Image src={Isms} width={95} height={86} alt={t('certifications.isms')} className="lg:w-[113px] lg:h-[103px]" />
       <Certification className="w-[72px] h-[86px] lg:w-[85px] lg:h-[102px]" aria-label={t('certifications.other')} />
       <VentureIcon className="w-[101px] h-[85px] lg:w-[120px] lg:h-[101px]" aria-label={t('certifications.venture')} />


### PR DESCRIPTION
- 640px 미만에서 2x2 그리드, sm 이상 한 줄 배치
- 작은 폰에서 로고 좌측 정렬 및 불필요한 여백 제거