### PR TITLE
feat(blog): 공유용 OG·트위터 카드와 JSON-LD 추가, main 중첩 수정

### DIFF
--- a/src/app/[locale]/blog/[slug]/page.tsx
+++ b/src/app/[locale]/blog/[slug]/page.tsx
@@ -13,21 +13,48 @@ interface BlogPostPageProps {
 // 선언해도 실제 산출물 없이 선언만 남아 Netlify 어댑터가 500을 낸다.
 // notice/[id]와 같은 순수 동적 라우트가 검증된 패턴이다.
 
+const BASE_URL = 'https://kodax.com';
+const DEFAULT_OG_IMAGE = `${BASE_URL}/assets/images/img-ogmeta_img.png`;
+
+// 'YYYY.MM.DD' → ISO 'YYYY-MM-DD'
+const toIsoDate = (date: string) => date.replaceAll('.', '-');
+
 export async function generateMetadata({ params }: BlogPostPageProps): Promise<Metadata> {
   const { locale, slug } = await params;
   const post = getPostBySlug(slug);
   if (!post) return {};
 
+  const url = `${BASE_URL}/${locale}/blog/${post.slug}`;
+  // OG를 명시하지 않으면 루트 레이아웃의 홈 OG가 상속돼 공유 카드가 잘못 나간다.
+  const ogImage = post.thumbnail ? `${BASE_URL}${post.thumbnail}` : DEFAULT_OG_IMAGE;
+
   return {
     title: post.title,
     description: post.description,
     alternates: {
-      canonical: `https://kodax.com/${locale}/blog/${post.slug}`,
+      canonical: url,
       languages: {
-        ko: `https://kodax.com/blog/${post.slug}`,
-        en: `https://kodax.com/en/blog/${post.slug}`,
-        'x-default': `https://kodax.com/blog/${post.slug}`,
+        ko: `${BASE_URL}/blog/${post.slug}`,
+        en: `${BASE_URL}/en/blog/${post.slug}`,
+        'x-default': `${BASE_URL}/blog/${post.slug}`,
       },
+    },
+    openGraph: {
+      type: 'article',
+      title: post.title,
+      description: post.description,
+      url,
+      siteName: 'KODA',
+      locale,
+      publishedTime: toIsoDate(post.date),
+      authors: [post.author.name],
+      images: [{ url: ogImage, alt: post.title }],
+    },
+    twitter: {
+      card: 'summary_large_image',
+      title: post.title,
+      description: post.description,
+      images: [ogImage],
     },
   };
 }
@@ -43,6 +70,20 @@ const BlogPostPage = async ({ params }: BlogPostPageProps) => {
 
   const related = getRelatedPosts(slug);
 
+  // 검색엔진용 구조화 데이터 (BlogPosting)
+  const jsonLd = {
+    '@context': 'https://schema.org',
+    '@type': 'BlogPosting',
+    headline: post.title,
+    description: post.description,
+    datePublished: toIsoDate(post.date),
+    author: { '@type': 'Person', name: post.author.name, jobTitle: post.author.role },
+    publisher: { '@type': 'Organization', name: 'KODA', url: BASE_URL },
+    image: post.thumbnail ? `${BASE_URL}${post.thumbnail}` : DEFAULT_OG_IMAGE,
+    mainEntityOfPage: `${BASE_URL}/blog/${post.slug}`,
+    inLanguage: 'ko',
+  };
+
   return (
     // 외곽(1440, relative) + 아티클(960 중앙) 구조. 본문 폭은 장문 가독성을
     // 위해 960px로 제한한다(팀 피드백). whitespace-pre-line은 TSX 본문이라 뺀다.
@@ -52,11 +93,14 @@ const BlogPostPage = async ({ params }: BlogPostPageProps) => {
       <article className="max-w-[960px] w-full mx-auto px-5">
         <PostHeader post={post} />
 
+        <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }} />
+
         {/* 헤딩 위 여백을 계층별로 차등(H2 > H3 > 문단) — 공용 typography 컴포넌트를
-            건드리지 않도록 블로그 본문에만 스코프해 오버라이드한다 */}
-        <main className="mt-8 lg:mt-12 [&_h2]:mt-14 lg:[&_h2]:mt-[72px] [&_h3]:mt-10 lg:[&_h3]:mt-12">
+            건드리지 않도록 블로그 본문에만 스코프해 오버라이드한다.
+            main은 레이아웃이 이미 감싸므로 여기선 div (중첩 main은 HTML 표준 위반) */}
+        <div className="mt-8 lg:mt-12 [&_h2]:mt-14 lg:[&_h2]:mt-[72px] [&_h3]:mt-10 lg:[&_h3]:mt-12">
           <ContentComponent />
-        </main>
+        </div>
 
         <ShareButtons title={post.title} />
 

--- a/src/app/[locale]/blog/page.tsx
+++ b/src/app/[locale]/blog/page.tsx
@@ -7,16 +7,34 @@ export async function generateMetadata({ params }: { params: Promise<{ locale: s
   const { locale } = await params;
   const t = await getTranslations({ locale, namespace: 'blog.meta' });
 
+  const url = `https://kodax.com/${locale}/blog`;
+  const ogImage = 'https://kodax.com/assets/images/img-ogmeta_img.png';
+
   return {
     title: t('title'),
     description: t('description'),
     alternates: {
-      canonical: `https://kodax.com/${locale}/blog`,
+      canonical: url,
       languages: {
         ko: 'https://kodax.com/blog',
         en: 'https://kodax.com/en/blog',
         'x-default': 'https://kodax.com/blog',
       },
+    },
+    openGraph: {
+      type: 'website',
+      title: t('title'),
+      description: t('description'),
+      url,
+      siteName: 'KODA',
+      locale,
+      images: [{ url: ogImage, alt: t('title') }],
+    },
+    twitter: {
+      card: 'summary_large_image',
+      title: t('title'),
+      description: t('description'),
+      images: [ogImage],
     },
   };
 }


### PR DESCRIPTION
## 개요

#117 머지 직후 푸시되어 빠진 커밋 1개입니다. 블로그 공유·SEO 메타 보강.

## 문제

블로그 페이지가 `openGraph`를 정의하지 않아 루트 레이아웃의 **홈 OG를 상속** — 글 링크를 카톡·슬랙·X에 공유하면 글 제목·요약 대신 홈 카드가 뜨는 상태였습니다.

## 변경

- **글별 OG 카드**: `og:type=article`, 글 제목·요약, 발행일·저자, `og:image`(썸네일 있으면 썸네일, 없으면 기본 이미지) + 트위터 `summary_large_image`
- **목록 페이지 OG** 추가
- **JSON-LD** `BlogPosting` 구조화 데이터 (검색엔진용)
- **`<main>` 중첩 수정** — 레이아웃 `<main>` 안에 상세 본문이 또 `<main>`을 쓰던 HTML 표준 위반 → `<div>`

## 검증

- lint·build 통과, 프로덕션 서버에서 og:* 태그 8종·JSON-LD·main 1개 렌더 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WaAvCkDPfZ7Q8tHuwBk5sc