### PR TITLE
fix(blog): 국문 로케일 메뉴·페이지 제목을 '기술 블로그'로

### DIFF
--- a/messages/ko.json
+++ b/messages/ko.json
@@ -6,7 +6,7 @@
       "notice": "공지사항",
       "faq": "자주 묻는 질문",
       "news": "언론 보도",
-      "blog": "Tech Blog"
+      "blog": "기술 블로그"
     },
     "button": {
       "contact": "서비스 문의"
@@ -1112,7 +1112,7 @@
   },
   "blog": {
     "list": {
-      "title": "Tech Blog",
+      "title": "기술 블로그",
       "featuredLabel": "최신 글"
     },
     "detail": {
@@ -1129,7 +1129,7 @@
       "title": "목차"
     },
     "meta": {
-      "title": "Tech Blog",
+      "title": "기술 블로그",
       "description": "KODA 기술 조직이 디지털자산 수탁을 만들며 쌓은 기술과 인사이트를 공유합니다."
     }
   }


### PR DESCRIPTION
## 개요

팀 피드백 반영 — 국문일 때 메뉴 이름을 "기술 블로그"로.

| 위치 | ko | en |
|---|---|---|
| 헤더 내비게이션 (데스크톱·모바일) | 기술 블로그 | Tech Blog |
| 목록 페이지 h1 | 기술 블로그 | Tech Blog |
| 브라우저 탭 타이틀 | 기술 블로그 | Tech Blog |

`messages/ko.json` 값 3곳 변경 (en 무변경, 코드 무변경).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WaAvCkDPfZ7Q8tHuwBk5sc