### PR TITLE
fix(blog): em 강조를 기울임 대신 색·굵기로 — 한글 faux italic 겹침 수정

### DIFF
--- a/docs/design/blog-post-workflow.md
+++ b/docs/design/blog-post-workflow.md
@@ -43,22 +43,22 @@ npm run lint && npm run build
 
 ## 노션 블록 → 컴포넌트 대응표
 
-| 노션 블록         | 컴포넌트                                                                                     | import                           |
-| ----------------- | -------------------------------------------------------------------------------------------- | -------------------------------- |
-| 제목2 (heading_2) | `H2`                                                                                         | `@/components/typography`        |
-| 제목3 (heading_3) | `H3`                                                                                         | `@/components/typography`        |
-| 문단 (paragraph)  | `P`                                                                                          | `@/components/typography`        |
-| 코드 (code)       | `CodeBlock`(`language` 프롭에 노션 언어값)                                                   | `@/components/blog/PostElements` |
-| 인라인 코드       | `InlineCode`                                                                                 | `@/components/blog/PostElements` |
-| 이미지 (image)    | `Figure`(이미지는 `public/assets/images/blog/`에 저장 후 경로 지정, `width`·`height` 실측값) | `@/components/blog/PostElements` |
-| 인용 (quote)      | `Blockquote`                                                                                 | `@/components/blog/PostElements` |
-| 콜아웃 (callout)  | `Callout`                                                                                    | `@/components/blog/PostElements` |
-| 글머리 기호 목록  | `Ul` + `Li`                                                                                  | `@/components/typography`        |
-| 번호 목록         | `Ol` + `Li`                                                                                  | `@/components/typography`        |
-| 표 (table)        | `TableContainer` + `Thead`/`Tbody`/`Tr`/`Th`/`Td`                                            | `@/components/typography`        |
-| 본문 내 외부 링크 | `TextLink`                                                                                   | `@/components/blog/PostElements` |
-| 굵게/기울임       | `<strong>` / `<em>`                                                                          | — (HTML 그대로)                  |
-| 구분선 (divider)  | 생략 — `H2`가 섹션 경계를 만들므로 옮기지 않는다                                             | —                                |
+| 노션 블록         | 컴포넌트                                                                                              | import                           |
+| ----------------- | ----------------------------------------------------------------------------------------------------- | -------------------------------- |
+| 제목2 (heading_2) | `H2`                                                                                                  | `@/components/typography`        |
+| 제목3 (heading_3) | `H3`                                                                                                  | `@/components/typography`        |
+| 문단 (paragraph)  | `P`                                                                                                   | `@/components/typography`        |
+| 코드 (code)       | `CodeBlock`(`language` 프롭에 노션 언어값)                                                            | `@/components/blog/PostElements` |
+| 인라인 코드       | `InlineCode`                                                                                          | `@/components/blog/PostElements` |
+| 이미지 (image)    | `Figure`(이미지는 `public/assets/images/blog/`에 저장 후 경로 지정, `width`·`height` 실측값)          | `@/components/blog/PostElements` |
+| 인용 (quote)      | `Blockquote`                                                                                          | `@/components/blog/PostElements` |
+| 콜아웃 (callout)  | `Callout`                                                                                             | `@/components/blog/PostElements` |
+| 글머리 기호 목록  | `Ul` + `Li`                                                                                           | `@/components/typography`        |
+| 번호 목록         | `Ol` + `Li`                                                                                           | `@/components/typography`        |
+| 표 (table)        | `TableContainer` + `Thead`/`Tbody`/`Tr`/`Th`/`Td`                                                     | `@/components/typography`        |
+| 본문 내 외부 링크 | `TextLink`                                                                                            | `@/components/blog/PostElements` |
+| 굵게/기울임       | `<strong>` / `<em>` (em은 상세 페이지가 기울임 대신 색·굵기 강조로 렌더 — 한글 faux italic 겹침 방지) | — (HTML 그대로)                  |
+| 구분선 (divider)  | 생략 — `H2`가 섹션 경계를 만들므로 옮기지 않는다                                                      | —                                |
 
 ## 변환 규칙
 

--- a/src/app/[locale]/blog/[slug]/page.tsx
+++ b/src/app/[locale]/blog/[slug]/page.tsx
@@ -98,7 +98,9 @@ const BlogPostPage = async ({ params }: BlogPostPageProps) => {
         {/* 헤딩 위 여백을 계층별로 차등(H2 > H3 > 문단) — 공용 typography 컴포넌트를
             건드리지 않도록 블로그 본문에만 스코프해 오버라이드한다.
             main은 레이아웃이 이미 감싸므로 여기선 div (중첩 main은 HTML 표준 위반) */}
-        <div className="mt-8 lg:mt-12 [&_h2]:mt-14 lg:[&_h2]:mt-[72px] [&_h3]:mt-10 lg:[&_h3]:mt-12">
+        {/* em(노션 기울임)은 한글 faux italic이 뒤 글자와 겹치므로 기울임 대신
+            색·굵기 강조로 표현한다 */}
+        <div className="mt-8 lg:mt-12 [&_h2]:mt-14 lg:[&_h2]:mt-[72px] [&_h3]:mt-10 lg:[&_h3]:mt-12 [&_em]:not-italic [&_em]:font-medium [&_em]:text-gray-900">
           <ContentComponent />
         </div>
 


### PR DESCRIPTION
## 개요

본문에서 기울임 강조된 한글("*분산할지*에")의 마지막 글자가 뒤 글자와 겹쳐 보이는 문제 수정입니다.

- **원인**: Pretendard에 이탤릭 글꼴이 없어 브라우저가 합성 기울임(faux italic)을 쓰는데, 기울어진 글자가 뒤 글자를 파고듦
- **조치**: 블로그 본문 스코프에서 `<em>`을 기울임 대신 **gray-900 + medium 굵기** 강조로 렌더 (한글 조판 관행). 노션 원문의 강조 의도는 유지
- 워크플로 문서 대응표에 명시

커밋 1개 (`a2c23ca`). #121 릴리스 PR에는 자동 포함돼 있습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WaAvCkDPfZ7Q8tHuwBk5sc